### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ or
 ```ruby
 require 'simple_operation/ext'
 
-CreateUser = SimpleOperation(:login, :password)
+CreateUser = SimpleOperation(:login, :password) do
   def call
     ...
   end


### PR DESCRIPTION
Added missing `do` in the Kernel Extension example.
